### PR TITLE
chore: upgrade http-cache-semantics to 2.0.1

### DIFF
--- a/.changeset/http-cache-semantics-v2.md
+++ b/.changeset/http-cache-semantics-v2.md
@@ -1,0 +1,9 @@
+---
+'@web-widget/shared-cache': minor
+---
+
+Upgrade to `@web-widget/http-cache-semantics` 2.0.1 and migrate cache policy evaluation to `evaluateRequest()`.
+
+- Normalize requests at the cache layer before calling `evaluateRequest()` (replacing removed `CacheQueryOptions`)
+- Use `evaluateRequest()` for stale-while-revalidate and synchronous revalidation
+- Rely on `revalidatedPolicy()` for stale-if-error handling (removed public `useStaleIfError()`)

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@edge-runtime/cookies": "^6.0.0",
-    "@web-widget/http-cache-semantics": "^1.2.0"
+    "@web-widget/http-cache-semantics": "^2.0.1"
   },
   "packageManager": "pnpm@10.11.1",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@web-widget/http-cache-semantics':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.1
@@ -980,8 +980,8 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@web-widget/http-cache-semantics@1.2.0':
-    resolution: {integrity: sha512-q/MobtHmwp3oaHmEATX/f6BJ+4bNMPVQ1nfDiNW9GkGI/JxRGhpOcs8wxdyr4tbcTgkuqjex8h9G7ONTDuVBmQ==}
+  '@web-widget/http-cache-semantics@2.0.1':
+    resolution: {integrity: sha512-JKJygfnKVCz+qsLgdGa9qOo1B9W+NpNK/RsdXPmiESsazSceMPwwLTkmP4Ni0UFfcDILnEVo9BFV2XejMgN7jA==}
 
   JSV@4.0.2:
     resolution: {integrity: sha512-ZJ6wx9xaKJ3yFUhq5/sk82PJMuUyLk277I8mQeyDgCTjGdjWJIvPfaU5LIXaMuaN2UO1X3kZH4+lgphublZUHw==}
@@ -4151,7 +4151,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@web-widget/http-cache-semantics@1.2.0': {}
+  '@web-widget/http-cache-semantics@2.0.1': {}
 
   JSV@4.0.2: {}
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,8 +9,9 @@ import type {
   SharedCacheRequest,
   SharedCacheRequestInfo,
 } from './types';
-import type { CachePolicyObject } from '@web-widget/http-cache-semantics';
-import CachePolicy from '@web-widget/http-cache-semantics';
+import CachePolicy, {
+  type CachePolicyObject,
+} from '@web-widget/http-cache-semantics';
 import { createLogger, StructuredLogger } from './utils/logger';
 import {
   appendVaryKeySuffix,
@@ -242,19 +243,14 @@ export class SharedCache implements WebCache {
     const fetch = options?._fetch;
     const policyObject = sanitizeStoredPolicy(cacheItem.policy);
     const policy = CachePolicy.fromObject(policyObject);
+    const evaluationRequest = normalizePolicyRequest(r, policyObject, options);
+    const evaluation = policy.evaluateRequest(evaluationRequest);
 
     const { body, status, statusText } = cacheItem.response;
-    const responseHeaders = policy.responseHeaders();
-    const stale = policy.stale();
-    const needsRevalidation =
-      !policy.satisfiesWithoutRevalidation(r, {
-        ignoreRequestCacheControl: options?._ignoreRequestCacheControl,
-        ignoreMethod: true,
-        ignoreSearch: true,
-        ignoreVary: true,
-      }) || stale;
 
-    if (needsRevalidation) {
+    if (evaluation.revalidation) {
+      const responseHeaders =
+        evaluation.response?.headers ?? policy.responseHeaders();
       const response = new Response(body, {
         status,
         statusText,
@@ -265,7 +261,7 @@ export class SharedCache implements WebCache {
         return;
       }
 
-      if (stale && policy.useStaleWhileRevalidate()) {
+      if (evaluation.revalidation.synchronous === false) {
         const event = options?._event;
         const waitUntil =
           event?.waitUntil.bind(event) ??
@@ -284,6 +280,7 @@ export class SharedCache implements WebCache {
         waitUntil(
           this.#revalidate(
             r,
+            evaluationRequest,
             {
               response,
               policy,
@@ -291,7 +288,7 @@ export class SharedCache implements WebCache {
             },
             cacheKey,
             fetch,
-            options
+            evaluation.revalidation.headers
           )
         );
         applyCacheStatus(response, UPDATING);
@@ -309,6 +306,7 @@ export class SharedCache implements WebCache {
 
       return this.#revalidate(
         r,
+        evaluationRequest,
         {
           response,
           policy,
@@ -316,9 +314,15 @@ export class SharedCache implements WebCache {
         },
         cacheKey,
         fetch,
-        options
+        evaluation.revalidation.headers
       );
     }
+
+    if (!evaluation.response) {
+      return;
+    }
+
+    const responseHeaders = evaluation.response.headers;
 
     if (
       hasConditionalRequestHeaders(r) &&
@@ -498,19 +502,14 @@ export class SharedCache implements WebCache {
    */
   async #revalidate(
     request: Request,
+    evaluationRequest: Request,
     resolveCacheItem: CachePolicyResponse,
     cacheKey: string,
     fetch: typeof globalThis.fetch,
-    options: SharedCacheQueryOptions | undefined
+    revalidationHeaders: Headers
   ): Promise<Response> {
-    // Create conditional request with validation headers (If-None-Match, If-Modified-Since)
-    const revalidationRequest = new Request(request, {
-      headers: resolveCacheItem.policy.revalidationHeaders(request, {
-        ignoreRequestCacheControl: options?._ignoreRequestCacheControl,
-        ignoreMethod: true,
-        ignoreSearch: true,
-        ignoreVary: true,
-      }),
+    const revalidationRequest = new Request(evaluationRequest, {
+      headers: revalidationHeaders,
     });
 
     let revalidationResponse: Response;
@@ -613,10 +612,7 @@ export class SharedCache implements WebCache {
         },
         'Serving fresh response'
       );
-    } else if (
-      isErrorResponse(revalidationResponse) &&
-      resolveCacheItem.policy.useStaleIfError()
-    ) {
+    } else if (isErrorResponse(revalidationResponse)) {
       applyCacheStatus(clonedResponse, STALE);
       this.#structuredLogger.info(
         'Serving stale response',
@@ -690,6 +686,35 @@ export class SharedCache implements WebCache {
       responseForVary
     );
   }
+}
+
+/**
+ * Normalizes a request for CachePolicy evaluation.
+ * Vary matching is handled at the cache-key layer; method, URL, and request
+ * headers are aligned with the stored policy metadata before calling evaluateRequest().
+ */
+function normalizePolicyRequest(
+  request: Request,
+  policyObject: CachePolicyObject,
+  options?: SharedCacheQueryOptions
+): Request {
+  const headers = new Headers(request.headers);
+
+  if (options?._ignoreRequestCacheControl) {
+    headers.delete('cache-control');
+    headers.delete('pragma');
+  }
+
+  if (policyObject.reqh) {
+    for (const [name, value] of Object.entries(policyObject.reqh)) {
+      headers.set(name, value);
+    }
+  }
+
+  return new Request(policyObject.u, {
+    method: policyObject.m,
+    headers,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Upgrade `@web-widget/http-cache-semantics` from `^1.2.0` to `^2.0.1`
- Migrate `SharedCache.match()` / revalidation flow to `evaluateRequest()` per 2.x API
- Add `normalizePolicyRequest()` to align stored policy URL/method/headers before policy evaluation (replaces removed `CacheQueryOptions`)
- Use `revalidatedPolicy()` for stale-if-error; drop public `useStaleIfError()` usage

## Test plan

- [x] `pnpm test` — 322 tests passed
- [x] Verify stale-while-revalidate serves stale response with `UPDATING` status
- [x] Verify stale-if-error serves cached body on origin 5xx
- [x] Verify fresh `must-revalidate` responses hit cache without unnecessary revalidation (fixed in http-cache-semantics 2.0.1)